### PR TITLE
Fix blank frames causing crash

### DIFF
--- a/reader/src/computed.rs
+++ b/reader/src/computed.rs
@@ -7,6 +7,7 @@ use std::{
 use image::{Pixel, Rgba, RgbaImage};
 use tracing::{error, warn};
 
+use crate::raw::RawAsepriteCel::Raw;
 use crate::{
     error::{AseResult, AsepriteError, AsepriteInvalidError},
     raw::{
@@ -702,7 +703,6 @@ impl<'a> AsepriteFrameRange<'a> {
             let image = image_for_frame(self.aseprite, frame)?;
             frames.push(image);
         }
-
         Ok(frames)
     }
 }
@@ -715,7 +715,26 @@ fn image_for_frame(aseprite: &Aseprite, frame: u16) -> AseResult<RgbaImage> {
             continue;
         }
 
-        let cel = layer.get_cel(frame as usize)?;
+        let blank_cel = AsepriteCel {
+            x: 0.0,
+            y: 0.0,
+            opacity: 0,
+            raw_cel: RawAsepriteCel::Raw {
+                width: dim.0,
+                height: dim.1,
+                pixels: vec![
+                    AsepritePixel::RGBA(AsepriteColor {
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                        alpha: 0,
+                    });
+                    (dim.0 * dim.1) as usize
+                ],
+            },
+        };
+
+        let cel = layer.get_cel(frame as usize).unwrap_or(&blank_cel);
 
         let mut write_to_image = |cel: &AsepriteCel,
                                   width: u16,

--- a/reader/src/computed.rs
+++ b/reader/src/computed.rs
@@ -715,26 +715,32 @@ fn image_for_frame(aseprite: &Aseprite, frame: u16) -> AseResult<RgbaImage> {
             continue;
         }
 
-        let blank_cel = AsepriteCel {
-            x: 0.0,
-            y: 0.0,
-            opacity: 0,
-            raw_cel: RawAsepriteCel::Raw {
-                width: dim.0,
-                height: dim.1,
-                pixels: vec![
-                    AsepritePixel::RGBA(AsepriteColor {
-                        red: 0,
-                        green: 0,
-                        blue: 0,
-                        alpha: 0,
-                    });
-                    (dim.0 * dim.1) as usize
-                ],
-            },
-        };
+        let mut blank_cel: AsepriteCel;
 
-        let cel = layer.get_cel(frame as usize).unwrap_or(&blank_cel);
+        let cel = match layer.get_cel(frame as usize) {
+            Ok(aseprite_cel) => aseprite_cel,
+            Err(_) => {
+                blank_cel = AsepriteCel {
+                    x: 0.0,
+                    y: 0.0,
+                    opacity: 0,
+                    raw_cel: RawAsepriteCel::Raw {
+                        width: dim.0,
+                        height: dim.1,
+                        pixels: vec![
+                            AsepritePixel::RGBA(AsepriteColor {
+                                red: 0,
+                                green: 0,
+                                blue: 0,
+                                alpha: 0,
+                            });
+                            (dim.0 * dim.1) as usize
+                        ],
+                    },
+                };
+                &blank_cel
+            }
+        };
 
         let mut write_to_image = |cel: &AsepriteCel,
                                   width: u16,


### PR DESCRIPTION
Fixed blank frames causing crashes. image_for_frame now creates a completely blank image of the right dimensions to use if the get_cel function returns an error.

The fix in #8 was not working for me. It fixed group caused crashes however any blank frames were still panicing out. This fix addresses those errors.

- fixes #7 