### PR TITLE
support custom_size

### DIFF
--- a/examples/show_aseprite.rs
+++ b/examples/show_aseprite.rs
@@ -79,6 +79,25 @@ fn change_animation(
             *player_anim = AsepriteAnimation::from(sprites::Player::tags::RIGHT_WALK);
         }
     }
+
+    if keys.pressed(KeyCode::S) {
+        for mut crow_anim in aseprites.p0().iter_mut() {
+            crow_anim.custom_size = Some(crow_anim.custom_size.unwrap_or(Vec2::splat(40.)) + Vec2::splat(- 2.));
+        }
+        for mut player_anim in aseprites.p1().iter_mut() {
+            player_anim.custom_size = Some(player_anim.custom_size.unwrap_or(Vec2::splat(40.)) + Vec2::splat(- 2.));
+        }
+    }
+
+    if keys.pressed(KeyCode::W) {
+        for mut crow_anim in aseprites.p0().iter_mut() {
+            crow_anim.custom_size = Some(crow_anim.custom_size.unwrap_or(Vec2::splat(40.)) + Vec2::splat(2.));
+        }
+        for mut player_anim in aseprites.p1().iter_mut() {
+            player_anim.custom_size = Some(player_anim.custom_size.unwrap_or(Vec2::splat(40.)) + Vec2::splat(2.));
+        }
+    }
+
     if keys.just_pressed(KeyCode::Space) {
         for mut crow_anim in aseprites.p0().iter_mut() {
             crow_anim.toggle();

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -24,11 +24,12 @@ impl AsepriteTag {
     }
 }
 
-#[derive(Debug, Component, PartialEq, Eq)]
+#[derive(Debug, Component, PartialEq)]
 pub struct AsepriteAnimation {
     pub is_playing: bool,
     tag: Option<String>,
     pub current_frame: usize,
+    pub custom_size: Option<Vec2>,
     forward: bool,
     time_elapsed: Duration,
     tag_changed: bool,
@@ -40,6 +41,7 @@ impl Default for AsepriteAnimation {
             is_playing: true,
             tag: Default::default(),
             current_frame: Default::default(),
+            custom_size: None,
             forward: Default::default(),
             time_elapsed: Default::default(),
             tag_changed: true,
@@ -197,6 +199,11 @@ impl AsepriteAnimation {
     pub fn toggle(&mut self) {
         self.is_playing = !self.is_playing;
     }
+    
+    pub const fn with_size(mut self, size: Option<Vec2>) -> Self {
+        self.custom_size = size;
+        self
+    }
 }
 
 pub(crate) fn update_animations(
@@ -223,6 +230,9 @@ pub(crate) fn update_animations(
                 continue;
             }
         };
+
+        sprite.custom_size = animation.custom_size;
+
         if animation.update(info, time.delta()) {
             sprite.index = aseprite.frame_to_idx[animation.current_frame];
         }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -141,13 +141,14 @@ pub(crate) fn insert_sprite_sheet(
                 continue;
             }
         };
-        let atlas = match aseprite.atlas.clone() {
+        let mut atlas = match aseprite.atlas.clone() {
             Some(atlas) => atlas,
             None => {
                 debug!("Aseprite atlas not ready");
                 continue;
             }
         };
+
         commands.entity(entity).insert(SpriteSheetBundle {
             texture_atlas: atlas,
             transform,


### PR DESCRIPTION
Support custom size via simply mirroring the property and updating it in `update_animations`

resolves mdenchev/bevy_aseprite#12