### PR TITLE
Add fn to get AsepriteAnimation component tag.

### DIFF
--- a/src/anim.rs
+++ b/src/anim.rs
@@ -197,6 +197,11 @@ impl AsepriteAnimation {
     pub fn toggle(&mut self) {
         self.is_playing = !self.is_playing;
     }
+
+    /// Get the current animation tag
+    pub fn tag(&self) -> String {
+        self.tag.clone().expect("AsepriteAnimation has no tag")
+    }
 }
 
 pub(crate) fn update_animations(


### PR DESCRIPTION
I needed this so maybe someone else will too :) Please let me know if there is some way to do this already that I didn't find.

**Example usage:**

```rust
/// Update to "moving" animation if we are are moving and not already playing it
pub fn update(mut query: Query<&mut AsepriteAnimation, (With<Player>, With<Moving>)>) {
    for (mut animation) in &mut query {
        if animation.tag() != sprites::Player::tags::RUNNING {
            *animation = AsepriteAnimation::from(sprites::Player::tags::RUNNING);
        }
    }
}
```