### PR TITLE
Add public `is_tag` fn to AsepriteAnimation.

### DIFF
--- a/src/anim.rs
+++ b/src/anim.rs
@@ -197,6 +197,11 @@ impl AsepriteAnimation {
     pub fn toggle(&mut self) {
         self.is_playing = !self.is_playing;
     }
+
+    /// Returns `true` if current animation tag matches `tag_name`
+    pub fn is_tag(&self, tag_name: &str) -> bool {
+        self.tag == Some(tag_name.to_string())
+    }
 }
 
 pub(crate) fn update_animations(


### PR DESCRIPTION
Usage:

```rust
if !anim.is_tag(sprites::Player::tags::RUNNING) {
    *anim = AsepriteAnimation::from(sprites::Player::tags::RUNNING);
}
```