### PR TITLE
Provide getter for tag

### DIFF
--- a/src/anim.rs
+++ b/src/anim.rs
@@ -173,6 +173,11 @@ impl AsepriteAnimation {
         self.current_frame
     }
 
+    /// Get the tag
+    pub fn tag(&self) -> Option<&str> {
+        self.tag.as_deref()
+    }
+
     /// Start or resume playing an animation
     pub fn play(&mut self) {
         self.is_playing = true;


### PR DESCRIPTION
When switching tags it is useful to know what the current tag is. It is useful to know when wanting to decide whether the correct tag is already being played. Without this getter one would have to manually track the state that already is there.